### PR TITLE
Add omitempty tag for Protocol field, make library a Go module

### DIFF
--- a/path/go.mod
+++ b/path/go.mod
@@ -1,0 +1,3 @@
+module github.com/path-network/go-path
+
+go 1.13

--- a/path/rules.go
+++ b/path/rules.go
@@ -7,7 +7,7 @@ type Rules struct {
 
 // Rule represents a rule entry in the firewall
 type Rule struct {
-	Protocol string `json:"protocol"`
+	Protocol string `json:"protocol,omitempty"`
 	// omitempty is required in the event that these values are not provided, as Go will default to 0, which will be
 	// recognized as an invalid port number
 	DstPort  int    `json:"dst_port,omitempty"`


### PR DESCRIPTION
These changes fix an issue where omitting the `Protocol` field for the `Rule` struct would default to `""`, which was being rejected by the API as an invalid protocol. When the field is not given a value, it should not be sent in the request. This lets the API know that the rule should apply to any protocol. Additionally, the library has been made as a Go module to support Go 1.16 and later being module-aware by default (see https://blog.golang.org/go116-module-changes).